### PR TITLE
Add ValidateFirmware action

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/metal-toolbox/ctrl v0.2.1
 	github.com/metal-toolbox/fleetdb v1.19.3
-	github.com/metal-toolbox/rivets v1.2.1-0.20240812182945-5478bc566ea3
+	github.com/metal-toolbox/rivets v1.3.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/metal-toolbox/ctrl v0.2.1 h1:CYOOsmX7SNBFJjxDIWWW76imGXlIfxO8KEKlUffX
 github.com/metal-toolbox/ctrl v0.2.1/go.mod h1:VfYYvY7SAvHjN+PTPsaahaazM7gKWq5s37aS3kX4KKo=
 github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U0k1GSec=
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
-github.com/metal-toolbox/rivets v1.2.1-0.20240812182945-5478bc566ea3 h1:bl4p8mWI6u/qYqpR9tIP+4U37n8waSqTuQgM2t5B0Sg=
-github.com/metal-toolbox/rivets v1.2.1-0.20240812182945-5478bc566ea3/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.0 h1:LfEWbOPy3Jh+8Zg4/GUIGX6kqMM9DI8s1zKZZIDtpcw=
+github.com/metal-toolbox/rivets v1.3.0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/internal/device/bmc.go
+++ b/internal/device/bmc.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bmc-toolbox/bmclib/v2"
+	"github.com/bmc-toolbox/bmclib/v2/constants"
 	"github.com/bmc-toolbox/bmclib/v2/providers"
 	logrusrv2 "github.com/bombsimon/logrusr/v2"
 	"github.com/metal-toolbox/flipflop/internal/model"
@@ -136,6 +137,15 @@ func (b *Bmc) PowerCycleBMC(ctx context.Context) error {
 	defer b.tracelog()
 	_, err := b.client.ResetBMC(ctx, "GracefulRestart")
 	return err
+}
+
+func (b *Bmc) HostBooted(ctx context.Context) (bool, error) {
+	defer b.tracelog()
+	status, _, err := b.client.PostCode(ctx)
+	if err != nil {
+		return false, err
+	}
+	return status == constants.POSTStateOS, nil
 }
 
 func (b *Bmc) tracelog() {

--- a/internal/device/dryRun.go
+++ b/internal/device/dryRun.go
@@ -120,6 +120,11 @@ func (b *DryRunBMC) PowerCycleBMC(_ context.Context) error {
 	return nil
 }
 
+// HostBooted reports whether or not the device has booted the host OS
+func (b *DryRunBMC) HostBooted(_ context.Context) (bool, error) {
+	return true, nil
+}
+
 // getServer gets a simulateed server state, and update power status and boot device if required
 func (b *DryRunBMC) getServer() (*serverState, error) {
 	server, ok := serverStates[b.id]

--- a/internal/device/interface.go
+++ b/internal/device/interface.go
@@ -13,4 +13,5 @@ type Queryor interface {
 	SetBootDevice(ctx context.Context, device string, persistent, efiBoot bool) error
 	GetBootDevice(ctx context.Context) (device string, persistent, efiBoot bool, err error)
 	PowerCycleBMC(ctx context.Context) error
+	HostBooted(ctx context.Context) (bool, error)
 }


### PR DESCRIPTION
#### What does this PR do

This patch adds a handler for the `validate_firmware` action added in https://github.com/metal-toolbox/rivets/pull/86 (and of course depends on it).

The implementation is kind of sketchy at the moment -- aside from the obvious downsides of it just being a simple synchronous polling loop, the use of POST codes as a pass/fail test has a couple potential problems:
 - at time of writing bmclib only implements POST code retrieval for ASRock factory BMC firmware, so we'd need to flesh that out for wider support across different providers.
 - a simple "current POST code" check is vulnerable to race conditions wherein we might observe a POST code from a previous successful boot and thus report a spurious pass.  We can hope that a sleep of a sufficient length after issuing the host reset is sufficient to avoid that window (i.e. that the host has updated its current POST code by the time we start polling it), or we could take a more aggressive approach and poll more rapidly to detect a change away from the initial POST code state before the reset and use that as a signal that it's actually done something and a subsequent "successful boot" POST code isn't just a stale one still sitting there from before (though that approach is in principle also still vulnerable to its own race conditions and such, in addition to the added load of higher-frequency polling).  OpenBMC's redfish interface provides a boot-count number that could be used to nicely (efficiently, reliably) avoid this problem, but I'm pretty sure it's unique to OpenBMC and not widely available from other kinds of BMCs.