### PR TITLE
Pxebootpersistent

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ image:
 env:
   facility: sandbox
   log_level: debug
-  dryrun: true
+  dryrun: false
   fault_injection: true
   endpoints:
     nats:
@@ -16,22 +16,6 @@ env:
       connection_timeout: 60s
       kv_replication: 1
       app_name: flipflop
-      # TODO: remove deprecated stream_urn_ns field
-      stream_urn_ns: hollow-controllers
-      consumer:
-        name: sandbox-flipflop
-        pull: true
-        ack_wait: 5m
-        max_ack_pending: 10
-        queue_group: flipflop
-      stream:
-        name: controllers
-        subjects:
-          - com.hollow.sh.controllers.commands.>
-          - com.hollow.sh.controllers.responses.>
-        acknowledgements: true
-        duplicate_window: 5m
-        retention: workQueue
     otel:
       url: jaeger:4317
       authenticate: false
@@ -39,13 +23,13 @@ env:
       authenticate: true
       url: http://fleetdb:8000
       oidc_audience_url: # to be filled by parent helm chart if authenticate is true
-      oidc_issuer_url:   # to be filled by parent helm chart if authenticate is true
+      oidc_issuer_url: # to be filled by parent helm chart if authenticate is true
       oidc_client_id: # to be filled by parent helm chart if authenticate is true
-      oidc_scopes:    # to be filled by parent helm chart if authenticate is true
+      oidc_scopes: # to be filled by parent helm chart if authenticate is true
     conditionorc:
       authenticate: true
       url: http://conditionorc-api:9001
       oidc_audience_url: # to be filled by parent helm chart if authenticate is true
-      oidc_issuer_url:   # to be filled by parent helm chart if authenticate is true
+      oidc_issuer_url: # to be filled by parent helm chart if authenticate is true
       oidc_client_id: # to be filled by parent helm chart if authenticate is true
-      oidc_scopes:    # to be filled by parent helm chart if authenticate is true
+      oidc_scopes: # to be filled by parent helm chart if authenticate is true

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/metal-toolbox/ctrl v0.2.1
 	github.com/metal-toolbox/fleetdb v1.19.3
-	github.com/metal-toolbox/rivets v1.3.0
+	github.com/metal-toolbox/rivets v1.3.2-0.20240821095555-56f1bf4b1a29
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,8 @@ github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
 github.com/metal-toolbox/rivets v1.3.0 h1:LfEWbOPy3Jh+8Zg4/GUIGX6kqMM9DI8s1zKZZIDtpcw=
 github.com/metal-toolbox/rivets v1.3.0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.2-0.20240821095555-56f1bf4b1a29 h1:m8suYpZ7V3IHwiEUFmcjo1KD19+ir6iXmY1a9rQo7Nk=
+github.com/metal-toolbox/rivets v1.3.2-0.20240821095555-56f1bf4b1a29/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=


### PR DESCRIPTION
#### What does this PR do

- Adds support for `PxeBootPersistent` serverControl - which handles setting PXE boot to persistent and powering on the server.
- Fixes up delays to allow context cancellation


depends on https://github.com/metal-toolbox/rivets/pull/90