### PR TITLE
Config viper bug fix

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           secret:
             secretName: flipflop-secrets
             items:
-              - key: flipflop-nats-creds
+              - key: nats-creds
                 path: nats.creds
       restartPolicy: Always
 {{ end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           secret:
             secretName: flipflop-secrets
             items:
-              - key: nats-creds
+              - key: flipflop-nats-creds
                 path: nats.creds
       restartPolicy: Always
 {{ end }}

--- a/config.yaml
+++ b/config.yaml
@@ -7,20 +7,21 @@ endpoints:
     oidc_audience_url:
     oidc_client_id:
     oidc_issuer_url:
-    oidc_scopes:
+    oidc_client_scopes:
     url: http://fleetdb:8000
   nats:
     app_name: flipflop
     connection_timeout: 60s
     consumer:
+      name: flipflop
       ack_wait: 5m
       max_ack_pending: 10
       pull: true
       queue_group: flipflop
-    creds:
-      file: /etc/nats/nats.creds
+    creds_file: /etc/nats/nats.creds
     kv_replication: 1
     stream:
+      user: flipflop
       acknowledgements: true
       duplicate_window: 5m
       name: controllers

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,12 @@ require (
 	github.com/equinix-labs/otel-init-go v0.0.9
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/jeremywohl/flatten v1.0.1
 	github.com/metal-toolbox/ctrl v0.2.1
 	github.com/metal-toolbox/fleetdb v1.19.3
 	github.com/metal-toolbox/rivets v1.3.2
 	github.com/mitchellh/copystructure v1.2.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/sirupsen/logrus v1.9.3
@@ -82,7 +84,6 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/jacobweinstock/iamt v0.0.0-20230502042727-d7cdbe67d9ef // indirect
 	github.com/jacobweinstock/registrar v0.4.7 // indirect
-	github.com/jeremywohl/flatten v1.0.1 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
@@ -92,7 +93,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/equinix-labs/otel-init-go v0.0.9
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/metal-toolbox/ctrl v0.2.2
+	github.com/metal-toolbox/ctrl v0.2.1
 	github.com/metal-toolbox/fleetdb v1.19.3
 	github.com/metal-toolbox/rivets v1.3.2
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/jacobweinstock/iamt v0.0.0-20230502042727-d7cdbe67d9ef // indirect
 	github.com/jacobweinstock/registrar v0.4.7 // indirect
+	github.com/jeremywohl/flatten v1.0.1 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,8 @@ github.com/jacobweinstock/iamt v0.0.0-20230502042727-d7cdbe67d9ef h1:G4k02HGmBUf
 github.com/jacobweinstock/iamt v0.0.0-20230502042727-d7cdbe67d9ef/go.mod h1:FgmiLTU6cJewV4Xgrq6m5o8CUlTQOJtqzaFLGA0mG+E=
 github.com/jacobweinstock/registrar v0.4.7 h1:s4dOExccgD+Pc7rJC+f3Mc3D+NXHcXUaOibtcEsPxOc=
 github.com/jacobweinstock/registrar v0.4.7/go.mod h1:PWmkdGFG5/ZdCqgMo7pvB3pXABOLHc5l8oQ0sgmBNDU=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/go.sum
+++ b/go.sum
@@ -553,6 +553,8 @@ github.com/metal-toolbox/ctrl v0.2.2 h1:8OFId6uxyVpwyS+Asmehs9PLwZrnBRWOc6viMVd6
 github.com/metal-toolbox/ctrl v0.2.2/go.mod h1:pN64bE8tqvG2x1YpS62lfwEPOzMh98lXwyF11t8VLYw=
 github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U0k1GSec=
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
+github.com/metal-toolbox/rivets v1.3.1 h1:UD70qh6KNNgCPivAP7Ed4U8H8aJ3+3Bw8FtyMXiM7Qg=
+github.com/metal-toolbox/rivets v1.3.1/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.2 h1:wazODpX94E2IbjuqEAmARl1r9TZE0NS1vBiGSpBW/tE=
 github.com/metal-toolbox/rivets v1.3.2/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=

--- a/go.sum
+++ b/go.sum
@@ -549,12 +549,10 @@ github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxU
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87 h1:C3Gkj7+bV18HgXJuzeJ6RAttzqsO6sDBF7I20x5JvWM=
 github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87/go.mod h1:0Rh7BPun3VcJzxsBfbZ94lxxxSUNLtugAeZPRWPcD3c=
-github.com/metal-toolbox/ctrl v0.2.2 h1:8OFId6uxyVpwyS+Asmehs9PLwZrnBRWOc6viMVd6/vc=
-github.com/metal-toolbox/ctrl v0.2.2/go.mod h1:pN64bE8tqvG2x1YpS62lfwEPOzMh98lXwyF11t8VLYw=
+github.com/metal-toolbox/ctrl v0.2.1 h1:CYOOsmX7SNBFJjxDIWWW76imGXlIfxO8KEKlUffXAak=
+github.com/metal-toolbox/ctrl v0.2.1/go.mod h1:VfYYvY7SAvHjN+PTPsaahaazM7gKWq5s37aS3kX4KKo=
 github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U0k1GSec=
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
-github.com/metal-toolbox/rivets v1.3.1 h1:UD70qh6KNNgCPivAP7Ed4U8H8aJ3+3Bw8FtyMXiM7Qg=
-github.com/metal-toolbox/rivets v1.3.1/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.2 h1:wazODpX94E2IbjuqEAmARl1r9TZE0NS1vBiGSpBW/tE=
 github.com/metal-toolbox/rivets v1.3.2/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -56,13 +56,17 @@ func (a *App) LoadConfiguration(cfgFilePath, loglevel string) error {
 	cfg := &Configuration{}
 	a.Config = cfg
 
-	setConfigDefaults(a.v, cfg, "", ".")
+	err := setConfigDefaults(a.v, cfg, "", ".")
+	if err != nil {
+		return err
+	}
+
 	a.v.SetConfigType("yaml")
 	a.v.SetEnvPrefix(model.AppName)
 	a.v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	a.v.AutomaticEnv()
 
-	err := a.ReadInFile(cfg, cfgFilePath)
+	err = a.ReadInFile(cfg, cfgFilePath)
 	if err != nil {
 		return err
 	}
@@ -154,7 +158,7 @@ func setConfigDefaults(v *viper.Viper, i interface{}, parent, delim string) erro
 		// If it's a struct, only bind properties.
 		if f.Type.Kind() == reflect.Struct {
 			t := reflect.New(f.Type).Elem().Interface()
-			setConfigDefaults(v, t, env, delim)
+			_ = setConfigDefaults(v, t, env, delim)
 			continue
 		}
 


### PR DESCRIPTION
#### What does this PR do

- Viper has a limitation that doesnt allow it to use ENV variables as overrides unless the key was found in the yaml that is read in. This leads to mysterious values not being set. So I added a function to read through and set a default value for every struct item in config so you never have to worry about it.

- Small fix for dummy config so it matches the Configuration struct.